### PR TITLE
add support for '//' comments

### DIFF
--- a/wmidump.c
+++ b/wmidump.c
@@ -126,16 +126,22 @@ static void parse_wdg(const void *data, size_t len)
 
 static void *parse_ascii_wdg(const char *wdg, size_t *bytes)
 {
-	static int comment = 0;
+	static int comment = 0, newline_comment = 0;
 	char *p = (char *)wdg;
 	char *data = NULL;
 
 	*bytes = 0;
 
 	for (; *p; p++) {
-		if (p[0] == '/' && p[1] == '*') {
-			comment++;
-			p++;
+		if (p[0] == '/') {
+			if (p[1] == '*') {
+				comment++;
+				p++;
+			}
+			else if (p[1] == '/') {
+				newline_comment++;
+				p++;
+			}
 			continue;
 		}
 		if (p[0] == '*' && p[1] == '/') {
@@ -143,7 +149,11 @@ static void *parse_ascii_wdg(const char *wdg, size_t *bytes)
 			p++;
 			continue;
 		}
-		if (comment)
+		if (p[0] == '\n' && newline_comment) {
+			newline_comment = 0;
+			continue;
+		}
+		if (comment || newline_comment)
 			continue;
 		if (!isalnum(*p))
 			continue;


### PR DESCRIPTION
`iasl` version 20200430 places a hexdump after each line of a buffer, like this:
```
Name (WQBA, Buffer (0x05DE)
            {
                /* 0000 */  0x46, 0x4F, 0x4D, 0x42, 0x01, 0x00, 0x00, 0x00,  // FOMB....
```
and this causes `wmidump` to parse it input incorrectly. This PR introduces support for `//` comments.