### PR TITLE
Print object_id or notify_id based on ACPI_WMI_EVENT flag

### DIFF
--- a/wmidump.c
+++ b/wmidump.c
@@ -104,9 +104,10 @@ static void parse_wdg(const void *data, size_t len)
 
 		wmi_gtoa(g->guid, guid_string);
 		printf("%s:\n", guid_string);
-		printf("\tobject_id: %c%c\n", g->object_id[0], g->object_id[1]);
-		printf("\tnotify_id: %02X\n", g->notify_id);
-		printf("\treserved: %02X\n", g->reserved);
+		if (g->flags & ACPI_WMI_EVENT)
+			printf("\tnotify_id: 0x%02X\n", g->notify_id);
+		else
+			printf("\tobject_id: %c%c\n", g->object_id[0], g->object_id[1]);
 		printf("\tinstance_count: %d\n", g->instance_count);
 		printf("\tflags: %#x", g->flags);
 		if (g->flags) {


### PR DESCRIPTION
object_id and notify_id member are in one union. It depends on
ACPI_WMI_EVENT flag which member is stored in this union.

So print only one member based on ACPI_WMI_EVENT flag.